### PR TITLE
Extend cgroup match to parse major:minor classification id

### DIFF
--- a/doc/ferm.pod
+++ b/doc/ferm.pod
@@ -633,15 +633,17 @@ Match using Linux Socket Filter.
 
 Match using cgroupsv2 hierarchy or legacy net_cls cgroup.
 
-    mod cgroup !path example/path ACCEPT;
+    mod cgroup path ! example/path ACCEPT;
 
-I<path> is relative to the root of the hiearchy, and is compared against the
-initial portion of a process' path in the hierarchy.
+The path is relative to the root of the cgroupsv2 hiearchy, and is compared
+against the initial portion of a process' path in the hierarchy.
 
-    mod cgroup cgroup classid DROP;
+    mod cgroup cgroup 10:10 DROP;
+    mod cgroup cgroup 1048592 DROP;
 
-I<classid> is a decimal unsigned 32-bit value compared against the value of
-C<net_cls.classid> set in the process' net_cls cgroup.
+Matches against the value of C<net_cls.classid> set on the process' legacy
+net_cls cgroup. The class may be specified as a hexadecimal major:minor pair
+(see L<tc(8)>), or as a decimal, so those two rules are equivalent.
 
 =item B<comment>
 

--- a/src/ferm
+++ b/src/ferm
@@ -242,7 +242,7 @@ add_match_def 'addrtype', qw(!src-type !dst-type),
   qw(limit-iface-in*0 limit-iface-out*0);
 add_match_def 'ah', qw(ahspi! ahlen! ahres*0);
 add_match_def 'bpf', qw(bytecode);
-add_match_def 'cgroup', qw(!path !cgroup);
+add_match_def 'cgroup', qw(path! cgroup&cgroup_classid);
 add_match_def 'comment', qw(comment=s);
 add_match_def 'condition', qw(condition!);
 add_match_def 'connbytes', qw(!connbytes connbytes-dir connbytes-mode);
@@ -500,6 +500,40 @@ sub address_magic {
         return bless \@ips, 'negated';
     } else {
         return \@ips;
+    }
+}
+
+sub cgroup_classid {
+    my $rule = shift;
+    my $value = getvalues(undef, allow_negation => 1);
+
+    my @classids;
+    my $negated = 0;
+    if (ref $value and ref $value eq 'ARRAY') {
+	@classids = @$value;
+    } elsif (ref $value and ref $value eq 'negated') {
+	@classids = @$value;
+	$negated = 1;
+    } elsif (ref $value) {
+	die;
+    } else {
+	@classids = ($value);
+    }
+
+    foreach (@classids) {
+	if ($_ =~ /^([0-9A-Fa-f]{1,4}):([0-9A-Fa-f]{1,4})$/) {
+	    $_ = (hex($1) << 16) + hex($2);
+	} elsif ($_ !~ /^-?\d+$/) {
+	    error('classid must be hex:hex or decimal');
+	}
+	error('classid must be non-negative') if $_ < 0;
+	error('classid is too large') if $_ > 0xffffffff;
+    }
+
+    if ($negated && scalar @classids) {
+	return bless \@classids, 'negated';
+    } else {
+	return \@classids;
     }
 }
 

--- a/test/modules/cgroup.ferm
+++ b/test/modules/cgroup.ferm
@@ -1,7 +1,9 @@
 table filter chain INPUT mod cgroup {
     cgroup 65537 ACCEPT;
+    cgroup a1b2:c3d4 ACCEPT;
     cgroup ! 32769 REJECT;
-    cgroup (1000 2000 3000) DROP;
+    cgroup ! 0:65 REJECT;
+    cgroup (1010 10:10) DROP;
     path foo/bar ACCEPT;
     path ! foo/bar REJECT;
     path (foo/bar baz/qux) ACCEPT;

--- a/test/modules/cgroup.result
+++ b/test/modules/cgroup.result
@@ -1,8 +1,9 @@
 iptables -t filter -A INPUT -m cgroup --cgroup 65537 -j ACCEPT
+iptables -t filter -A INPUT -m cgroup --cgroup 2712847316 -j ACCEPT
 iptables -t filter -A INPUT -m cgroup ! --cgroup 32769 -j REJECT
-iptables -t filter -A INPUT -m cgroup --cgroup 1000 -j DROP
-iptables -t filter -A INPUT -m cgroup --cgroup 2000 -j DROP
-iptables -t filter -A INPUT -m cgroup --cgroup 3000 -j DROP
+iptables -t filter -A INPUT -m cgroup ! --cgroup 101 -j REJECT
+iptables -t filter -A INPUT -m cgroup --cgroup 1010 -j DROP
+iptables -t filter -A INPUT -m cgroup --cgroup 1048592 -j DROP
 iptables -t filter -A INPUT -m cgroup --path foo/bar -j ACCEPT
 iptables -t filter -A INPUT -m cgroup ! --path foo/bar -j REJECT
 iptables -t filter -A INPUT -m cgroup --path foo/bar -j ACCEPT


### PR DESCRIPTION
This brings us in line with the format accepted for the CLASSIFY target,
and is otherwise useful if the cgroup matcher is being used in
conjunction with tc(8).