### PR TITLE
Fix SYNPROXY timestamp option

### DIFF
--- a/src/ferm
+++ b/src/ferm
@@ -345,7 +345,7 @@ add_target_def 'SECMARK', qw(selctx);
 add_target_def 'SET', qw(add-set=sc del-set=sc timeout exist*0);
 add_target_def 'SNAT', qw(to-source=m to:=to-source persistent*0 random*0);
 add_target_def 'SNPT', qw(src-pfx dst-pfx);
-add_target_def 'SYNPROXY', qw(sack-perm*0 timestamps*0 ecn*0 wscale=s mss=s);
+add_target_def 'SYNPROXY', qw(sack-perm*0 timestamp*0 ecn*0 wscale=s mss=s);
 add_target_def 'TARPIT';
 add_target_def 'TCPMSS', qw(set-mss clamp-mss-to-pmtu*0);
 add_target_def 'TCPOPTSTRIP', qw(strip-options=c);


### PR DESCRIPTION
Commit 52026e00 renamed SYNPROXY's `timestamp` option to `timestamps`, presumably following iptables' documentation[1]. However, the current iptables source[2] still calls the option `timestamp` and fails when`--timestamps` is passed:

```
# iptables -j SYNPROXY --timestamps
iptables v1.6.0: unknown option "--timestamps"
```

Fix this by renaming the `timestamps` options back to `timestamp`.

[1] https://git.netfilter.org/iptables/tree/extensions/libxt_SYNPROXY.man
[2] https://git.netfilter.org/iptables/plain/extensions/libxt_SYNPROXY.c