### PR TITLE
Fixed ipv4options against newer iptables

### DIFF
--- a/src/ferm
+++ b/src/ferm
@@ -269,7 +269,7 @@ add_match_def 'hashlimit', qw(hashlimit=s hashlimit-burst=s hashlimit-mode=c has
   qw(hashlimit-htable-size=s hashlimit-htable-max=s),
   qw(hashlimit-htable-expire=s hashlimit-htable-gcinterval=s);
 add_match_def 'iprange', qw(!src-range !dst-range);
-add_match_def 'ipv4options', qw(ssrr*0 lsrr*0 no-srr*0 !rr*0 !ts*0 !ra*0 !any-opt*0);
+add_match_def 'ipv4options', qw(flags!=c any*0);
 add_match_def 'ipv6header', qw(header!=c soft*0);
 add_match_def 'ipvs', qw(!ipvs*0 !vproto !vaddr !vport vdir !vportctl);
 add_match_def 'length', qw(length!);

--- a/test/modules/ipv4options.ferm
+++ b/test/modules/ipv4options.ferm
@@ -1,13 +1,3 @@
 chain INPUT {
-    mod ipv4options ssrr ACCEPT;
-    mod ipv4options lsrr ACCEPT;
-    mod ipv4options no-srr ACCEPT;
-    mod ipv4options rr ACCEPT;
-    mod ipv4options !rr DROP;
-    mod ipv4options ts ACCEPT;
-    mod ipv4options !ts DROP;
-    mod ipv4options ra ACCEPT;
-    mod ipv4options !ra DROP;
-    mod ipv4options any-opt ACCEPT;
-    mod ipv4options !any-opt DROP;
+    mod ipv4options flags (ssrr lsrr timestamp record-route) any DROP;
 }

--- a/test/modules/ipv4options.result
+++ b/test/modules/ipv4options.result
@@ -1,11 +1,1 @@
-iptables -t filter -A INPUT -m ipv4options --ssrr -j ACCEPT
-iptables -t filter -A INPUT -m ipv4options --lsrr -j ACCEPT
-iptables -t filter -A INPUT -m ipv4options --no-srr -j ACCEPT
-iptables -t filter -A INPUT -m ipv4options --rr -j ACCEPT
-iptables -t filter -A INPUT -m ipv4options ! --rr -j DROP
-iptables -t filter -A INPUT -m ipv4options --ts -j ACCEPT
-iptables -t filter -A INPUT -m ipv4options ! --ts -j DROP
-iptables -t filter -A INPUT -m ipv4options --ra -j ACCEPT
-iptables -t filter -A INPUT -m ipv4options ! --ra -j DROP
-iptables -t filter -A INPUT -m ipv4options --any-opt -j ACCEPT
-iptables -t filter -A INPUT -m ipv4options ! --any-opt -j DROP
+iptables -t filter -A INPUT -m ipv4options --flags ssrr,lsrr,timestamp,record-route --any -j DROP


### PR DESCRIPTION
This PR resolves an issue experienced on Ubuntu 16.04.3 LTS where the Ferm generated iptables rules are incorrectly generated, for the newer iptables version.

Due to the Ferm PR change; a working example of a Ferm rule is now:

```
mod ipv4options flags (ssrr lsrr timestamp record-route) any DROP;
```
