### PR TITLE
Making chain name length validation an error not a warning (was testi…

### DIFF
--- a/src/ferm
+++ b/src/ferm
@@ -2311,7 +2311,7 @@ sub enter($$) {
                 my $domain = $rule{domain};
                 foreach my $table (to_array $rule{table}) {
                     foreach my $c (to_array $chain) {
-                        warning("Chain name too long, must be 29 charactersi or less: $c") if length($c) > 29;
+                        error("Chain name too long, must be 29 characters or less: $c") if length($c) > 29;
                         $domains{$domain}{tables}{$table}{chains}{$c} ||= {};
                     }
                 }


### PR DESCRIPTION
…ng truncating the name, the potential for chain name clash is too high). Fixing typo in error message

Sorry for the mess! Had a typo in the original PR