### PR TITLE
Update parameters of the time module

### DIFF
--- a/doc/ferm.pod
+++ b/doc/ferm.pod
@@ -1150,8 +1150,8 @@ Check if the time a packet arrives is in given range.
     mod time datestop 2005:04:01;
     mod time monthday (30 31);
     mod time weekdays (Wed Thu);
-    mod time timestart 12:00 utc;
-    mod time timestart 12:00 localtz;
+    mod time timestart 12:00;
+    mod time timestart 12:00 kerneltz;
 
 Type "iptables -m time -h" for details.
 

--- a/src/ferm
+++ b/src/ferm
@@ -302,7 +302,7 @@ add_match_def 'statistic', qw(mode=s probability=s every=s packet=s);
 add_match_def 'string', qw(algo=s from=s to=s string hex-string);
 add_match_def 'tcpmss', qw(!mss);
 add_match_def 'time', qw(timestart=s timestop=s days=c datestart=s datestop=s),
-  qw(!monthday=c !weekdays=c utc*0 localtz*0);
+  qw(!monthday=c !weekdays=c kerneltz*0);
 add_match_def 'tos', qw(!tos);
 add_match_def 'ttl', qw(ttl-eq ttl-lt=s ttl-gt=s);
 add_match_def 'u32', qw(!u32=m);

--- a/test/modules/time.ferm
+++ b/test/modules/time.ferm
@@ -10,8 +10,8 @@ table filter chain INPUT mod time {
         REJECT;
     }
     datestop 2004/12/31 DROP;
-    datestop 2004/12/31 timestart 09:00 utc DROP;
-    datestop 2004/12/31 timestart 18:00 localtz DROP;
+    datestop 2004/12/31 timestart 09:00 DROP;
+    datestop 2004/12/31 timestart 18:00 kerneltz DROP;
     monthday (1 2 3) ACCEPT;
     weekdays (Mon Tue Wed) ACCEPT;
 }

--- a/test/modules/time.result
+++ b/test/modules/time.result
@@ -5,7 +5,7 @@ iptables -t filter -A INPUT -m time --days Fri,Sat -j REJECT
 iptables -t filter -A INPUT -m time -p tcp --dport http --datestart 2005/02/01 -j ACCEPT
 iptables -t filter -A INPUT -m time -p tcp --dport http -j REJECT
 iptables -t filter -A INPUT -m time --datestop 2004/12/31 -j DROP
-iptables -t filter -A INPUT -m time --datestop 2004/12/31 --timestart 09:00 --utc -j DROP
-iptables -t filter -A INPUT -m time --datestop 2004/12/31 --timestart 18:00 --localtz -j DROP
+iptables -t filter -A INPUT -m time --datestop 2004/12/31 --timestart 09:00 -j DROP
+iptables -t filter -A INPUT -m time --datestop 2004/12/31 --timestart 18:00 --kerneltz -j DROP
 iptables -t filter -A INPUT -m time --monthday 1,2,3 -j ACCEPT
 iptables -t filter -A INPUT -m time --weekdays Mon,Tue,Wed -j ACCEPT


### PR DESCRIPTION
Remove the utc parameter, it is not available any more because its the default.
The localtz parameter was renamed to kerneltz.