### PR TITLE
@resolve: Correctly handle empty NOERROR responses from Net::DNS

### DIFF
--- a/src/ferm
+++ b/src/ferm
@@ -1164,7 +1164,8 @@ sub resolve($\@$) {
 
         my $query = $resolver->search($hostname, $type);
         error("DNS query for '$hostname' failed: " . $resolver->errorstring)
-          unless $query;
+	    unless $resolver->errorstring eq 'NOERROR';
+	next unless $query;
 
         foreach my $rr ($query->answer) {
             next unless $rr->type eq $type;

--- a/src/ferm
+++ b/src/ferm
@@ -1164,8 +1164,8 @@ sub resolve($\@$) {
 
         my $query = $resolver->search($hostname, $type);
         error("DNS query for '$hostname' failed: " . $resolver->errorstring)
-	    unless $resolver->errorstring eq 'NOERROR';
-	next unless $query;
+            unless $resolver->errorstring eq 'NOERROR';
+        next unless $query;
 
         foreach my $rr ($query->answer) {
             next unless $rr->type eq $type;


### PR DESCRIPTION
Per https://phabricator.wikimedia.org/T153468 and https://rt.cpan.org/Ticket/Display.html?id=127182

Net::DNS::Resolver->search will return undef when given a NOERROR result with an empty answer section. That's not an error and we should just respect the result of 0 records.