### PR TITLE
Use ebtables atomic functionality when applying eb domain rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ $(STAMPDIR)/test/arptables/%.result: test/arptables/%.ferm src/ferm
 
 $(STAMPDIR)/test/ebtables/%.result: test/ebtables/%.ferm src/ferm
 	@mkdir -p $(dir $@)
-	$(PERL) src/ferm --test --slow $< |sed $(EB_ARP_RESULT_SED) >$@
+	$(PERL) src/ferm --test --slow $< |$(PERL) test/ebtables_tempfile_rename.pl |sed $(EB_ARP_RESULT_SED) >$@
 
 $(STAMPDIR)/%.result: %.ferm src/ferm test/sort.pl
 	@mkdir -p $(dir $@)

--- a/src/ferm
+++ b/src/ferm
@@ -29,6 +29,7 @@
 # $Id$
 
 use File::Spec;
+use File::Temp;
 
 BEGIN {
     eval { require strict; import strict; };
@@ -140,7 +141,7 @@ sub resolve($\@$);
 sub enter($$);
 sub rollback();
 sub execute_fast($);
-sub execute_slow($);
+sub execute_slow($$);
 sub join_value($$);
 sub ipfilter($@);
 
@@ -691,7 +692,7 @@ foreach my $domain (sort keys %domains) {
     next unless $domain_info->{enabled};
     my $s = $option{fast} &&
       defined $domain_info->{tools}{'tables-restore'}
-      ? execute_fast($domain_info) : execute_slow($domain_info);
+      ? execute_fast($domain_info) : execute_slow($domain_info, $domain);
     $status = $s if defined $s;
 }
 
@@ -842,6 +843,14 @@ sub initialize_domain {
           exists $tools{'tables-save'}) {
         print LINES "${domain}_tmp=\$(mktemp ferm.XXXXXXXXXX)\n";
         print LINES "$tools{'tables-save'} >\$${domain}_tmp\n";
+    }
+
+    if ($domain eq 'eb') {
+        my $tempfile = File::Temp->new(TEMPLATE => 'ferm.XXXXXXXXXX', TMPDIR => 1, OPEN => 0, UNLINK => 1);
+        my $filename = $tempfile->filename;
+        my $domain_cmd = $domain_info->{tools}{tables};
+        execute_command("$domain_cmd --atomic-file $filename --atomic-save");
+        $domain_info->{ebt_previous} = $tempfile;
     }
 
     $domain_info->{initialized} = 1;
@@ -2575,10 +2584,19 @@ sub execute_command {
     return;
 }
 
-sub execute_slow($) {
+sub execute_slow($$) {
     my $domain_info = shift;
+    my $domain = shift;
 
     my $domain_cmd = $domain_info->{tools}{tables};
+
+    if ($domain eq 'eb') {
+        my $tempfile = File::Temp->new(TEMPLATE => 'ferm.XXXXXXXXXX', TMPDIR => 1, OPEN => 0, UNLINK => 1);
+        my $filename = $tempfile->filename;
+        $domain_info->{ebt_current} = $tempfile;
+        $domain_cmd .= " --atomic-file $filename";
+        execute_command("$domain_cmd --atomic-init");
+    }
 
     my $status;
     while (my ($table, $table_info) = each %{$domain_info->{tables}}) {
@@ -2625,6 +2643,10 @@ sub execute_slow($) {
                 $status ||= execute_command($chain_cmd . $rule->{rule});
             }
         }
+    }
+
+    if ($domain eq 'eb') {
+        execute_command("$domain_cmd --atomic-commit");
     }
 
     return $status;
@@ -2759,6 +2781,12 @@ sub rollback() {
     my $error;
     while (my ($domain, $domain_info) = each %domains) {
         next unless $domain_info->{enabled};
+        if ($domain eq 'eb') {
+            my $previous_rules = $domain_info->{ebt_previous}->filename;
+            my $domain_cmd = $domain_info->{tools}{tables};
+            execute_command("$domain_cmd --atomic-file $previous_rules --atomic-commit");
+            next;
+        }
         unless (defined $domain_info->{tools}{'tables-restore'}) {
             print STDERR "Cannot rollback domain '$domain' because there is no ${domain}tables-restore\n";
             next;

--- a/test/ebtables/basic.result
+++ b/test/ebtables/basic.result
@@ -1,14 +1,17 @@
-ebtables -t filter -P INPUT ACCEPT
-ebtables -t filter -F
-ebtables -t filter -X
-ebtables -t filter -A INPUT --source 00:11:22:33:44:55 -j DROP
-ebtables -t filter -A INPUT --among-src 00:11:22:33:44:55,00:11:22:33:44:66 -j DROP
-ebtables -t filter -A INPUT --protocol IPv4 --ip-source 192.168.1.1 -j DROP
-ebtables -t filter -A INPUT --protocol IPv4 --ip-protocol tcp --ip-destination-port 22 -j ACCEPT
-ebtables -t filter -A INPUT --protocol IPv6 --ip6-source 2001:db8:ffff:ffff:211:22ff:fe33:4455 -j DROP
-ebtables -t filter -A INPUT --protocol ARP --arp-mac-src 00:11:22:33:44:55 -j ACCEPT
-ebtables -t filter -A INPUT --protocol ARP --arp-gratuitous -j ACCEPT
-ebtables -t filter -A INPUT --protocol 0x8137 -j DROP
-ebtables -t filter -A INPUT --limit 30/hour -j DROP
-ebtables -t filter -A INPUT --in-interface eth0 --logical-in br0 --out-interface eth1 --logical-out br1 -j ACCEPT
-ebtables -t filter -A INPUT --source Multicast --destination Broadcast -j DROP
+ebtables --atomic-file /tmp/ferm.0 --atomic-save
+ebtables --atomic-file /tmp/ferm.1 --atomic-init
+ebtables --atomic-file /tmp/ferm.1 -t filter -P INPUT ACCEPT
+ebtables --atomic-file /tmp/ferm.1 -t filter -F
+ebtables --atomic-file /tmp/ferm.1 -t filter -X
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --source 00:11:22:33:44:55 -j DROP
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --among-src 00:11:22:33:44:55,00:11:22:33:44:66 -j DROP
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --protocol IPv4 --ip-source 192.168.1.1 -j DROP
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --protocol IPv4 --ip-protocol tcp --ip-destination-port 22 -j ACCEPT
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --protocol IPv6 --ip6-source 2001:db8:ffff:ffff:211:22ff:fe33:4455 -j DROP
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --protocol ARP --arp-mac-src 00:11:22:33:44:55 -j ACCEPT
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --protocol ARP --arp-gratuitous -j ACCEPT
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --protocol 0x8137 -j DROP
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --limit 30/hour -j DROP
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --in-interface eth0 --logical-in br0 --out-interface eth1 --logical-out br1 -j ACCEPT
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --source Multicast --destination Broadcast -j DROP
+ebtables --atomic-file /tmp/ferm.1 --atomic-commit

--- a/test/ebtables/negated.result
+++ b/test/ebtables/negated.result
@@ -1,8 +1,11 @@
-ebtables -t filter -P INPUT ACCEPT
-ebtables -t filter -F
-ebtables -t filter -X
-ebtables -t filter -A INPUT ! --among-src 00:11:22:33:44:55,00:11:22:33:44:66 -j ACCEPT
-ebtables -t filter -A INPUT ! --protocol ARP -j ACCEPT
-ebtables -t filter -A INPUT --protocol ARP ! --arp-gratuitous -j ACCEPT
-ebtables -t filter -A INPUT ! --in-interface eth0 ! --logical-in br0 ! --out-interface eth1 ! --logical-out br1 -j ACCEPT
-ebtables -t filter -A INPUT ! --source Multicast ! --destination Broadcast -j DROP
+ebtables --atomic-file /tmp/ferm.0 --atomic-save
+ebtables --atomic-file /tmp/ferm.1 --atomic-init
+ebtables --atomic-file /tmp/ferm.1 -t filter -P INPUT ACCEPT
+ebtables --atomic-file /tmp/ferm.1 -t filter -F
+ebtables --atomic-file /tmp/ferm.1 -t filter -X
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT ! --among-src 00:11:22:33:44:55,00:11:22:33:44:66 -j ACCEPT
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT ! --protocol ARP -j ACCEPT
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --protocol ARP ! --arp-gratuitous -j ACCEPT
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT ! --in-interface eth0 ! --logical-in br0 ! --out-interface eth1 ! --logical-out br1 -j ACCEPT
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT ! --source Multicast ! --destination Broadcast -j DROP
+ebtables --atomic-file /tmp/ferm.1 --atomic-commit

--- a/test/ebtables/targets.result
+++ b/test/ebtables/targets.result
@@ -1,9 +1,12 @@
-ebtables -t filter -P INPUT ACCEPT
-ebtables -t filter -F
-ebtables -t filter -X
-ebtables -t filter -A INPUT --logical-in br0 -j arpreply --arpreply-mac 00:00:de:ad:be:ef --arpreply-target DROP
-ebtables -t filter -A INPUT --logical-in br1 -j dnat --to-destination 00:00:de:ad:be:ef --dnat-target DROP
-ebtables -t filter -A INPUT --logical-in br2 -j mark --set-mark 1 --mark-target DROP
-ebtables -t filter -A INPUT --logical-in br3 -j redirect --redirect-target DROP
-ebtables -t filter -A INPUT --logical-in br4 -j snat --to-source 00:00:de:ad:be:ef --snat-target DROP
-ebtables -t filter -A INPUT --logical-in br4 -j snat --to-source 00:00:de:ad:be:ef --snat-target DROP --snat-arp
+ebtables --atomic-file /tmp/ferm.0 --atomic-save
+ebtables --atomic-file /tmp/ferm.1 --atomic-init
+ebtables --atomic-file /tmp/ferm.1 -t filter -P INPUT ACCEPT
+ebtables --atomic-file /tmp/ferm.1 -t filter -F
+ebtables --atomic-file /tmp/ferm.1 -t filter -X
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --logical-in br0 -j arpreply --arpreply-mac 00:00:de:ad:be:ef --arpreply-target DROP
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --logical-in br1 -j dnat --to-destination 00:00:de:ad:be:ef --dnat-target DROP
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --logical-in br2 -j mark --set-mark 1 --mark-target DROP
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --logical-in br3 -j redirect --redirect-target DROP
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --logical-in br4 -j snat --to-source 00:00:de:ad:be:ef --snat-target DROP
+ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --logical-in br4 -j snat --to-source 00:00:de:ad:be:ef --snat-target DROP --snat-arp
+ebtables --atomic-file /tmp/ferm.1 --atomic-commit

--- a/test/ebtables_tempfile_rename.pl
+++ b/test/ebtables_tempfile_rename.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/perl -w
+
+# This script renames ebtables temporary file suffixes consistently
+# from the result files so that tests can be done.
+
+use strict;
+
+my $matches = 0;
+
+while (<>) {
+    if ($matches eq 0) {
+        s/--atomic-file \/tmp\/ferm.(\w+) /--atomic-file \/tmp\/ferm.0 /;
+        $matches = 1;
+    } else {
+        s/--atomic-file \/tmp\/ferm.(\w+) /--atomic-file \/tmp\/ferm.1 /;
+    }
+    print $_;
+}
+

--- a/test/sort.pl
+++ b/test/sort.pl
@@ -23,7 +23,7 @@ my $table;
 while (<>) {
     next if /^#/;
 
-    if (/^(\w+)tables -t (\w+) -([NAP]) (\S+)/ or
+    if (/^(\w+)tables(?: --atomic-file \w+)? -t (\w+) -([NAP]) (\S+)/ or
           /^(\w+)tables -t (\w+) -([FX])()$/) {
         my $key = $3 eq 'P' ? "$1 $2  $4" : "$1 $2 $4";
         $key .= ' z' if $4 eq '';
@@ -40,6 +40,10 @@ while (<>) {
         push @$array, $_;
     } elsif (/^(:)(\S+)/ or /^-(A) (\S+)/) {
         my $key = $table . $1 . $2;
+        my $array = $rules{$key} ||= [];
+        push @$array, $_;
+    } elsif (/^ebtables --atomic-file (\S+) (\N+)/) {
+        my $key = $1;
         my $array = $rules{$key} ||= [];
         push @$array, $_;
     } else {


### PR DESCRIPTION
Ebtables command has `--atomic-*` switches to allow atomic save/restore functionality. This pull-request changes existing code to use atomic operations for eb domain and as a bonus enables rollback for interactive rule commits.

Newer versions of ebtables do have ebtables-restore/save but at the time of this PR they were not documented and ebtables-save had some questionable logic (such as /proc/modules being required). Due to this and ebtables-save/restore not being included in some distributions I tested the changes are made into the "slow" path of ferm. In the future if ebtables-restore/save commands are revised and documented better it might be viable to switch to using them instead.