### PR TITLE
fix ebtables non-filter table functionality

### DIFF
--- a/src/ferm
+++ b/src/ferm
@@ -88,6 +88,10 @@ use vars qw(%deprecated_keywords);
 # these hashes provide the Netfilter module definitions
 use vars qw(%proto_defs %match_defs %target_defs);
 
+# these are ebtables tables that we manage
+use vars qw(@eb_tables);
+@eb_tables = qw(filter nat broute);
+
 #
 # This subsubsystem allows you to support (most) new netfilter modules
 # in ferm.  Add a call to one of the "add_XY_def()" functions below.
@@ -941,11 +945,13 @@ sub initialize_domain {
     }
 
     if ($domain eq 'eb') {
-        my $tempfile = File::Temp->new(TEMPLATE => 'ferm.XXXXXXXXXX', TMPDIR => 1, OPEN => 0, UNLINK => 1);
-        my $filename = $tempfile->filename;
         my $domain_cmd = $domain_info->{tools}{tables};
-        execute_command("$domain_cmd --atomic-file $filename --atomic-save");
-        $domain_info->{ebt_previous} = $tempfile;
+        foreach my $eb_table (@eb_tables) {
+            my $tempfile = File::Temp->new(TEMPLATE => 'ferm.XXXXXXXXXX', TMPDIR => 1, OPEN => 0, UNLINK => 1);
+            my $filename = $tempfile->filename;
+            execute_command("$domain_cmd -t $eb_table --atomic-file $filename --atomic-save");
+            $domain_info->{ebt_previous}->{$eb_table} = $tempfile;
+        }
     }
 
     $domain_info->{initialized} = 1;
@@ -2835,16 +2841,23 @@ sub execute_slow($$) {
     my $domain_cmd = $domain_info->{tools}{tables};
 
     if ($domain eq 'eb') {
-        my $tempfile = File::Temp->new(TEMPLATE => 'ferm.XXXXXXXXXX', TMPDIR => 1, OPEN => 0, UNLINK => 1);
-        my $filename = $tempfile->filename;
-        $domain_info->{ebt_current} = $tempfile;
-        $domain_cmd .= " --atomic-file $filename";
-        execute_command("$domain_cmd --atomic-init");
+        foreach my $eb_table (@eb_tables) {
+            my $tempfile = File::Temp->new(TEMPLATE => 'ferm.XXXXXXXXXX', TMPDIR => 1, OPEN => 0, UNLINK => 1);
+            my $filename = $tempfile->filename;
+            $domain_info->{ebt_current}->{$eb_table} = $tempfile;
+            execute_command("$domain_cmd -t $eb_table --atomic-file $filename --atomic-init");
+            execute_command("$domain_cmd -t $eb_table --atomic-file $filename --init-table");
+        }
     }
 
     my $status;
     while (my ($table, $table_info) = each %{$domain_info->{tables}}) {
         my $table_cmd = "$domain_cmd -t $table";
+
+        if ($domain eq 'eb') {
+            my $tablefile = $domain_info->{ebt_current}->{$table}->filename;
+            $table_cmd = "$domain_cmd -t $table --atomic-file $tablefile"
+        }
 
         # reset chain policies
         while (my ($chain, $chain_info) = each %{$table_info->{chains}}) {
@@ -2890,7 +2903,10 @@ sub execute_slow($$) {
     }
 
     if ($domain eq 'eb') {
-        execute_command("$domain_cmd --atomic-commit");
+        foreach my $eb_table (@eb_tables) {
+            my $tablefile = $domain_info->{ebt_current}->{$eb_table}->filename;
+            execute_command("$domain_cmd -t $eb_table --atomic-file $tablefile --atomic-commit");
+        }
     }
 
     return $status;
@@ -3028,9 +3044,11 @@ sub rollback() {
     while (my ($domain, $domain_info) = each %domains) {
         next unless $domain_info->{enabled};
         if ($domain eq 'eb') {
-            my $previous_rules = $domain_info->{ebt_previous}->filename;
-            my $domain_cmd = $domain_info->{tools}{tables};
-            execute_command("$domain_cmd --atomic-file $previous_rules --atomic-commit");
+            foreach my $eb_table (@eb_tables) {
+                my $previous_rules = $domain_info->{ebt_previous}->{$eb_table}->filename;
+                my $domain_cmd = $domain_info->{tools}{tables};
+                execute_command("$domain_cmd -t $eb_table --atomic-file $previous_rules --atomic-commit");
+            }
             next;
         }
         unless (defined $domain_info->{tools}{'tables-restore'}) {

--- a/test/ebtables/basic.result
+++ b/test/ebtables/basic.result
@@ -1,17 +1,26 @@
-ebtables --atomic-file /tmp/ferm.0 --atomic-save
-ebtables --atomic-file /tmp/ferm.1 --atomic-init
-ebtables --atomic-file /tmp/ferm.1 -t filter -P INPUT ACCEPT
-ebtables --atomic-file /tmp/ferm.1 -t filter -F
-ebtables --atomic-file /tmp/ferm.1 -t filter -X
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --source 00:11:22:33:44:55 -j DROP
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --among-src 00:11:22:33:44:55,00:11:22:33:44:66 -j DROP
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --protocol IPv4 --ip-source 192.168.1.1 -j DROP
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --protocol IPv4 --ip-protocol tcp --ip-destination-port 22 -j ACCEPT
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --protocol IPv6 --ip6-source 2001:db8:ffff:ffff:211:22ff:fe33:4455 -j DROP
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --protocol ARP --arp-mac-src 00:11:22:33:44:55 -j ACCEPT
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --protocol ARP --arp-gratuitous -j ACCEPT
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --protocol 0x8137 -j DROP
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --limit 30/hour -j DROP
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --in-interface eth0 --logical-in br0 --out-interface eth1 --logical-out br1 -j ACCEPT
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --source Multicast --destination Broadcast -j DROP
-ebtables --atomic-file /tmp/ferm.1 --atomic-commit
+ebtables -t filter --atomic-file /tmp/ferm.0 --atomic-save
+ebtables -t nat --atomic-file /tmp/ferm.0 --atomic-save
+ebtables -t broute --atomic-file /tmp/ferm.0 --atomic-save
+ebtables -t filter --atomic-file /tmp/ferm.1 --atomic-init
+ebtables -t filter --atomic-file /tmp/ferm.1 --init-table
+ebtables -t nat --atomic-file /tmp/ferm.1 --atomic-init
+ebtables -t nat --atomic-file /tmp/ferm.1 --init-table
+ebtables -t broute --atomic-file /tmp/ferm.1 --atomic-init
+ebtables -t broute --atomic-file /tmp/ferm.1 --init-table
+ebtables -t filter --atomic-file /tmp/ferm.1 -P INPUT ACCEPT
+ebtables -t filter --atomic-file /tmp/ferm.1 -F
+ebtables -t filter --atomic-file /tmp/ferm.1 -X
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT --source 00:11:22:33:44:55 -j DROP
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT --among-src 00:11:22:33:44:55,00:11:22:33:44:66 -j DROP
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT --protocol IPv4 --ip-source 192.168.1.1 -j DROP
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT --protocol IPv4 --ip-protocol tcp --ip-destination-port 22 -j ACCEPT
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT --protocol IPv6 --ip6-source 2001:db8:ffff:ffff:211:22ff:fe33:4455 -j DROP
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT --protocol ARP --arp-mac-src 00:11:22:33:44:55 -j ACCEPT
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT --protocol ARP --arp-gratuitous -j ACCEPT
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT --protocol 0x8137 -j DROP
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT --limit 30/hour -j DROP
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT --in-interface eth0 --logical-in br0 --out-interface eth1 --logical-out br1 -j ACCEPT
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT --source Multicast --destination Broadcast -j DROP
+ebtables -t filter --atomic-file /tmp/ferm.1 --atomic-commit
+ebtables -t nat --atomic-file /tmp/ferm.1 --atomic-commit
+ebtables -t broute --atomic-file /tmp/ferm.1 --atomic-commit

--- a/test/ebtables/negated.result
+++ b/test/ebtables/negated.result
@@ -1,11 +1,20 @@
-ebtables --atomic-file /tmp/ferm.0 --atomic-save
-ebtables --atomic-file /tmp/ferm.1 --atomic-init
-ebtables --atomic-file /tmp/ferm.1 -t filter -P INPUT ACCEPT
-ebtables --atomic-file /tmp/ferm.1 -t filter -F
-ebtables --atomic-file /tmp/ferm.1 -t filter -X
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT ! --among-src 00:11:22:33:44:55,00:11:22:33:44:66 -j ACCEPT
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT ! --protocol ARP -j ACCEPT
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --protocol ARP ! --arp-gratuitous -j ACCEPT
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT ! --in-interface eth0 ! --logical-in br0 ! --out-interface eth1 ! --logical-out br1 -j ACCEPT
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT ! --source Multicast ! --destination Broadcast -j DROP
-ebtables --atomic-file /tmp/ferm.1 --atomic-commit
+ebtables -t filter --atomic-file /tmp/ferm.0 --atomic-save
+ebtables -t nat --atomic-file /tmp/ferm.0 --atomic-save
+ebtables -t broute --atomic-file /tmp/ferm.0 --atomic-save
+ebtables -t filter --atomic-file /tmp/ferm.1 --atomic-init
+ebtables -t filter --atomic-file /tmp/ferm.1 --init-table
+ebtables -t nat --atomic-file /tmp/ferm.1 --atomic-init
+ebtables -t nat --atomic-file /tmp/ferm.1 --init-table
+ebtables -t broute --atomic-file /tmp/ferm.1 --atomic-init
+ebtables -t broute --atomic-file /tmp/ferm.1 --init-table
+ebtables -t filter --atomic-file /tmp/ferm.1 -P INPUT ACCEPT
+ebtables -t filter --atomic-file /tmp/ferm.1 -F
+ebtables -t filter --atomic-file /tmp/ferm.1 -X
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT ! --among-src 00:11:22:33:44:55,00:11:22:33:44:66 -j ACCEPT
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT ! --protocol ARP -j ACCEPT
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT --protocol ARP ! --arp-gratuitous -j ACCEPT
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT ! --in-interface eth0 ! --logical-in br0 ! --out-interface eth1 ! --logical-out br1 -j ACCEPT
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT ! --source Multicast ! --destination Broadcast -j DROP
+ebtables -t filter --atomic-file /tmp/ferm.1 --atomic-commit
+ebtables -t nat --atomic-file /tmp/ferm.1 --atomic-commit
+ebtables -t broute --atomic-file /tmp/ferm.1 --atomic-commit

--- a/test/ebtables/targets.result
+++ b/test/ebtables/targets.result
@@ -1,12 +1,21 @@
-ebtables --atomic-file /tmp/ferm.0 --atomic-save
-ebtables --atomic-file /tmp/ferm.1 --atomic-init
-ebtables --atomic-file /tmp/ferm.1 -t filter -P INPUT ACCEPT
-ebtables --atomic-file /tmp/ferm.1 -t filter -F
-ebtables --atomic-file /tmp/ferm.1 -t filter -X
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --logical-in br0 -j arpreply --arpreply-mac 00:00:de:ad:be:ef --arpreply-target DROP
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --logical-in br1 -j dnat --to-destination 00:00:de:ad:be:ef --dnat-target DROP
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --logical-in br2 -j mark --set-mark 1 --mark-target DROP
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --logical-in br3 -j redirect --redirect-target DROP
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --logical-in br4 -j snat --to-source 00:00:de:ad:be:ef --snat-target DROP
-ebtables --atomic-file /tmp/ferm.1 -t filter -A INPUT --logical-in br4 -j snat --to-source 00:00:de:ad:be:ef --snat-target DROP --snat-arp
-ebtables --atomic-file /tmp/ferm.1 --atomic-commit
+ebtables -t filter --atomic-file /tmp/ferm.0 --atomic-save
+ebtables -t nat --atomic-file /tmp/ferm.0 --atomic-save
+ebtables -t broute --atomic-file /tmp/ferm.0 --atomic-save
+ebtables -t filter --atomic-file /tmp/ferm.1 --atomic-init
+ebtables -t filter --atomic-file /tmp/ferm.1 --init-table
+ebtables -t nat --atomic-file /tmp/ferm.1 --atomic-init
+ebtables -t nat --atomic-file /tmp/ferm.1 --init-table
+ebtables -t broute --atomic-file /tmp/ferm.1 --atomic-init
+ebtables -t broute --atomic-file /tmp/ferm.1 --init-table
+ebtables -t filter --atomic-file /tmp/ferm.1 -P INPUT ACCEPT
+ebtables -t filter --atomic-file /tmp/ferm.1 -F
+ebtables -t filter --atomic-file /tmp/ferm.1 -X
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT --logical-in br0 -j arpreply --arpreply-mac 00:00:de:ad:be:ef --arpreply-target DROP
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT --logical-in br1 -j dnat --to-destination 00:00:de:ad:be:ef --dnat-target DROP
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT --logical-in br2 -j mark --set-mark 1 --mark-target DROP
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT --logical-in br3 -j redirect --redirect-target DROP
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT --logical-in br4 -j snat --to-source 00:00:de:ad:be:ef --snat-target DROP
+ebtables -t filter --atomic-file /tmp/ferm.1 -A INPUT --logical-in br4 -j snat --to-source 00:00:de:ad:be:ef --snat-target DROP --snat-arp
+ebtables -t filter --atomic-file /tmp/ferm.1 --atomic-commit
+ebtables -t nat --atomic-file /tmp/ferm.1 --atomic-commit
+ebtables -t broute --atomic-file /tmp/ferm.1 --atomic-commit

--- a/test/ebtables_tempfile_rename.pl
+++ b/test/ebtables_tempfile_rename.pl
@@ -8,12 +8,8 @@ use strict;
 my $matches = 0;
 
 while (<>) {
-    if ($matches eq 0) {
-        s/--atomic-file \/tmp\/ferm.(\w+) /--atomic-file \/tmp\/ferm.0 /;
-        $matches = 1;
-    } else {
-        s/--atomic-file \/tmp\/ferm.(\w+) /--atomic-file \/tmp\/ferm.1 /;
-    }
+    s/--atomic-file \/tmp\/ferm.(\w+) /--atomic-file \/tmp\/ferm.1 /;
+    s/--atomic-file \/tmp\/ferm.(\w+) --atomic-save/--atomic-file \/tmp\/ferm.0 --atomic-save/;
     print $_;
 }
 

--- a/test/sort.pl
+++ b/test/sort.pl
@@ -54,8 +54,8 @@ while (<>) {
         my $key = $table . $1 . $2;
         my $array = $rules{$key} ||= [];
         push @$array, $_;
-    } elsif (/^ebtables --atomic-file (\S+) (\N+)/) {
-        my $key = $1;
+    } elsif (/^ebtables -t (\w+) --atomic-file (\S+) (\N+)/) {
+        my $key = $2;
         my $array = $rules{$key} ||= [];
         push @$array, $_;
     } else {


### PR DESCRIPTION
ebtables-atomic introduced a regression which causes non-filter tables to stop working, this PR re-introduces support for broute and nat tables :)

In the original PR I hadn't considered that ebtables atomic functionality needs file for each table...