### PR TITLE
Template service file so paths match $PREFIX.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ doc/ferm.1
 doc/ferm.html
 doc/ferm.txt
 doc/import-ferm.1
+ferm.service
 *.tmp

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,15 @@ DISTDIR = build/ferm-$(VERSION)
 
 .PHONY: all clean
 
-all: doc/ferm.txt doc/ferm.html doc/ferm.1 doc/import-ferm.1
+all: doc/ferm.txt doc/ferm.html doc/ferm.1 doc/import-ferm.1 ferm.service
 
 clean:
 	rm -rf build
 	rm -f doc/ferm.txt doc/ferm.html doc/ferm.1 doc/import-ferm.1 *.tmp
+	rm -f ferm.service
+
+ferm.service: ferm.service.in
+	sed 's|@prefix@|$(PREFIX)|g' $< > $@
 
 #
 # documentation

--- a/ferm.service.in
+++ b/ferm.service.in
@@ -4,8 +4,8 @@ Description=for Easy Rule Making
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/sbin/ferm /etc/ferm.conf
-ExecStop=/usr/sbin/ferm -F /etc/ferm.conf
+ExecStart=@prefix@/sbin/ferm /etc/ferm.conf
+ExecStop=@prefix@/sbin/ferm -F /etc/ferm.conf
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Otherwise, installing with, e.g., `make PREFIX=/usr/local` will install a broken service file.