### PR TITLE
add support for JOOL SIIT/NAT64 implementation

### DIFF
--- a/doc/ferm.pod
+++ b/doc/ferm.pod
@@ -1310,6 +1310,22 @@ options.
 
     IPV4OPTSSTRIP;
 
+=item B<JOOL>
+
+Hands off packets for stateful NAT64 translation via JOOL. Target
+requires JOOL to be installed on the system and the jool kernel module
+to be loaded.
+
+    JOOL instance "foo";
+
+=item B<JOOL_SIIT>
+
+Hands off packets for Stateless IP/ICMP Translation (SIIT) via JOOL.
+Target requires JOOL to be installed on the system and the jool_siit
+kernel module to be loaded.
+
+    JOOL_SIIT instance "foo";
+
 =item B<LED>
 
 This creates an LED-trigger that can then be attached to system

--- a/src/ferm
+++ b/src/ferm
@@ -331,6 +331,8 @@ add_target_def 'HMARK', qw(hmark-tuple hmark-mod hmark-offset),
   qw(hmark-dport-mask hmark-spi-mask hmark-proto-mask hmark-rnd);
 add_target_def 'IDLETIMER', qw(timeout label);
 add_target_def 'IPV4OPTSSTRIP';
+add_target_def 'JOOL', qw(instance);
+add_target_def 'JOOL_SIIT', qw(instance);
 add_target_def 'LED', qw(led-trigger-id led-delay led-always-blink*0);
 add_target_def 'LOG', qw(log-level log-prefix),
   qw(log-tcp-sequence*0 log-tcp-options*0 log-ip-options*0 log-uid*0);

--- a/test/targets/jool.ferm
+++ b/test/targets/jool.ferm
@@ -1,0 +1,5 @@
+table mangle {
+    chain PREROUTING {
+        JOOL instance test;
+    }
+}

--- a/test/targets/jool.result
+++ b/test/targets/jool.result
@@ -1,0 +1,1 @@
+iptables -t mangle -A PREROUTING -j JOOL --instance test

--- a/test/targets/jool_siit.ferm
+++ b/test/targets/jool_siit.ferm
@@ -1,0 +1,5 @@
+table mangle {
+    chain PREROUTING {
+        JOOL_SIIT instance test;
+    }
+}

--- a/test/targets/jool_siit.result
+++ b/test/targets/jool_siit.result
@@ -1,0 +1,1 @@
+iptables -t mangle -A PREROUTING -j JOOL_SIIT --instance test


### PR DESCRIPTION
this PR adds support for the SIIT/NAT64 implementation JOOL.

JOOL supports netfilter and iptables; for the iptables mode the targets JOOL and JOOL_SIIT are provided and corresponding iptables rules must be created.

You can find more information in the official documentation of JOOL:
 - https://www.jool.mx/en/run-vanilla.html
 - https://www.jool.mx/en/run-nat64.html